### PR TITLE
Add padding for devices with a notch (iPhone X and the like)

### DIFF
--- a/mobile/mobile.scss
+++ b/mobile/mobile.scss
@@ -26,6 +26,7 @@ html:not(.anon) {
   bottom: 0;
   z-index: z("dropdown") - 1;
   box-shadow: 0px -2px 4px -1px rgba(0, 0, 0, 0.25);
+  padding-bottom: env(safe-area-inset-bottom); // for devices with a notch (iPhone X*)
 
   .tab {
     color: $primary-medium;


### PR DESCRIPTION
Before: 
<img width="373" alt="image" src="https://user-images.githubusercontent.com/368961/62140732-7e598280-b2b9-11e9-9742-a9a1f340d819.png">

After: 
<img width="374" alt="image" src="https://user-images.githubusercontent.com/368961/62140668-671a9500-b2b9-11e9-89fd-bc1f72093491.png">

The amount of padding added is calculated by the device itself. 