### PR TITLE
FIX: Don't read site.mobileView during app initialization

### DIFF
--- a/javascripts/d-tab-bar/initializers/init-tab-bar.js
+++ b/javascripts/d-tab-bar/initializers/init-tab-bar.js
@@ -33,11 +33,11 @@ export default {
 
   initialize() {
     withPluginApi("0.8.13", (api) => {
-      const site = api.container.lookup("service:site");
-      if (!site.mobileView) {
-        return;
-      }
-
+      // No viewport check here: reading `site.mobileView` during
+      // initialization is deprecated (discourse.static-viewport-initialization)
+      // and would freeze the boot-time value. The tab bar component itself
+      // checks `site.mobileView` reactively at render time; the handlers below
+      // are no-ops while the tab bar isn't rendered.
       const user = api.getCurrentUser();
       if (!user) {
         return;


### PR DESCRIPTION
Since Discourse 3.5.0.beta9-dev, `site.mobileView` is viewport-based and reading it during app initialization triggers the `discourse.static-viewport-initialization` deprecation (https://meta.discourse.org/t/367810). Site admins running this component now see an admin notice saying the theme contains code which needs updating.

This removes the static viewport check from the initializer. It's safe to drop entirely because:

- The `d-tab-bar` connector component already gates rendering on `site.mobileView` reactively at render time, which is the recommended pattern.
- The route/`page:changed` highlight handlers registered by the initializer are no-ops while the tab bar isn't rendered (they query `.d-tab-bar .tab`, which doesn't exist on desktop).
- As a bonus, tab highlighting now keeps working when a window is resized into mobile width mid-session, matching the new responsive behavior of `mobileView`.

Tested: ESLint/Prettier pass, and the change has been deployed on a production Discourse site — the admin notice clears and the tab bar renders and highlights correctly on mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)